### PR TITLE
Add attribute for XSLT, closes #37

### DIFF
--- a/doc/user/basic_usage_guide/part_1.rst
+++ b/doc/user/basic_usage_guide/part_1.rst
@@ -56,6 +56,7 @@ Commonly used
     p.feed_url = "https://example.com/feeds/podcast.rss"  # URL of this feed
     p.category = Category("Technology", "Podcasting")
     p.owner = p.authors[0]
+    p.xslt = "https://example.com/feed/stylesheet.xsl"  # URL of XSLT stylesheet
 
 Read more:
 
@@ -65,6 +66,7 @@ Read more:
 * :attr:`~podgen.Podcast.feed_url`
 * :attr:`~podgen.Podcast.category`
 * :attr:`~podgen.Podcast.owner`
+* :attr:`~podgen.Podcast.xslt`
 
 
 Less commonly used

--- a/podgen/__main__.py
+++ b/podgen/__main__.py
@@ -57,6 +57,7 @@ def main():
     p.complete = False
     p.new_feed_url = 'http://example.com/new-feed.rss'
     p.owner = Person('John Doe', 'john@example.com')
+    p.xslt = "http://example.com/stylesheet.xsl"
 
     e1 = p.add_episode()
     e1.id = 'http://lernfunk.de/_MEDIAID_123#1'


### PR DESCRIPTION
As a consequence, rss_file will now use rss_str internally.
This means that the rss result is loaded into memory even
when writing to files, which could mean much poorer
performance for huge feeds in particular. If this is too
much, then we might reverse this commit, but I don't think
it will be much of a problem.