### PR TITLE
Add methods for notifying hubs, closes #21

### DIFF
--- a/doc/advanced/extending.rst
+++ b/doc/advanced/extending.rst
@@ -4,10 +4,6 @@ Adding new tags
 Are there XML elements you want to use that aren't supported by PodGen? If so,
 you should be able to add them in using inheritance.
 
-.. warning::
-
-   This is an advanced topic.
-
 .. note::
 
    There hasn't been a focus on making it easy to extend PodGen.

--- a/doc/advanced/index.rst
+++ b/doc/advanced/index.rst
@@ -1,0 +1,8 @@
+Advanced Topics
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   pubsubhubbub
+   extending

--- a/doc/advanced/pubsubhubbub.rst
+++ b/doc/advanced/pubsubhubbub.rst
@@ -1,0 +1,153 @@
+Using PubSubHubbub
+==================
+
+PubSubHubbub is a free and open protocol for pushing updates to clients
+when there's new content available in the feed, as opposed to the traditional
+polling clients do.
+
+Read about `what PubSubHubbub is`_ before you continue.
+
+.. _what PubSubHubbub is: https://en.wikipedia.org/wiki/PubSubHubbub
+
+.. note::
+
+   While the protocol supports having multiple PubSubHubbub hubs for a single
+   Podcast, there is no support for this in PodGen at the moment.
+
+--------------------------------------------------------------------------------
+
+.. contents::
+   :backlinks: none
+
+
+Step 1: Set feed_url
+--------------------
+
+First, you must ensure that the :class:`.Podcast` object has the
+:attr:`~.Podcast.feed_url` attribute set to the URL at which the feed is
+accessible.
+
+::
+
+    # Assume p is a Podcast object
+    p.feed_url = "https://example.com/feeds/examplefeed.rss"
+
+Step 2: Decide on a hub
+-----------------------
+
+The `Wikipedia article`_ mentions a few options you can use (called Community
+Hosted hub providers). Alternatively, you can set up and host your own server
+using one of the implementations found at the `official PubSubHubbub project
+page`_.
+
+.. _Wikipedia article: https://en.wikipedia.org/wiki/PubSubHubbub#Usage
+.. _official PubSubHubbub project page: https://github.com/pubsubhubbub
+
+Step 3: Set pubsubhubbub
+------------------------
+
+The Podcast must contain information about which hub to use. You do this by
+setting :attr:`~.Podcast.pubsubhubbub` to the URL which the hub is available at.
+
+::
+
+    p.pubsubhubbub = "https://pubsubhubbub.example.com/"
+
+Step 4: Set HTTP Link Header
+----------------------------
+
+In addition to embedding the PubSubHubbub hub URL and the feed's URL in the
+RSS itself, you should use the
+`Link header`_ in the HTTP response that is sent with this feed,
+duplicating the link to the PubSubHubbub and the feed. Example of
+what it might look like:
+
+.. code-block:: none
+
+   Link: <https://link.to.pubsubhubbub.example.org/>; rel="hub",
+         <https://example.org/podcast.rss>; rel="self"
+
+How you can achieve this varies from framework to framework. Here is an example
+using Flask (assuming the code is inside a view function)::
+
+    from flask import make_response
+    from podgen import Podcast
+    # ...
+    @app.route("/<feedname>")  # Just as an example
+    def show_feed(feedname):
+        p = Podcast()
+        # ...
+        # This is the relevant part:
+        response = make_response(str(p))
+        response.headers.add("Link", "<%s>" % p.pubsubhubbub, rel="hub")
+        response.headers.add("Link", "<%s>" % p.feed_url, rel="self")
+        return response
+
+This is necessary for compatibility with the different versions of
+PubSubHubbub. The `latest version of the standard`_ specifically says
+that publishers MUST use the Link header. If you're unable to do this, you
+can try publishing the feed without; most clients and hubs should manage
+just fine.
+
+.. _Link header: https://tools.ietf.org/html/rfc5988#page-6
+.. _latest version of the standard: http://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#rfc.section.4
+
+Step 5: Publish the changes
+---------------------------
+
+Ensure the changes above are published before proceeding. That is, if a client
+downloads the feed, it should receive the Link headers and the pubsubhubbub
+and feed_url contents.
+
+Step 6: Notify the hub of new episodes
+--------------------------------------
+
+.. note::
+
+   PodGen does not contain any logic for figuring out whether a Podcast has
+   changed or not. You must do that part yourself.
+
+PodGen has two convenience methods that you can use to notify the hub you chose
+of any additions made to the feed. The way this works, is that you say to the
+hub "Hey, we've made additions to this feed", and the hub looks at the feed and
+determines what is new, and sends the new episode(s) to any subscribed clients.
+
+There are three pre-requisites for using those methods:
+
+#. The `Requests`_ module has been installed.
+#. The :class:`.Podcast` object must have :attr:`~.Podcast.pubsubhubbub` and
+   :attr:`~.Podcast.feed_url` set.
+#. The new episodes will be included in the feed if someone requests the feed
+   at the moment the methods are called.
+
+   * If this isn't true, the hub will always be lagging one change behind!
+
+.. _Requests: http://docs.python-requests.org
+
+One of the methods work best when only one feed has changed. The other one can
+handle both the case where one feed has changed, and the case where multiple
+feeds have changed.
+
+.. autosummary::
+   podgen.Podcast.notify_hub
+   podgen.Podcast.notify_multiple
+
+Example where one Podcast has changed::
+
+    import requests
+    from podgen import Podcast
+    # ...
+    p.notify_hub(requests)
+
+Example where multiple Podcasts have changed::
+
+    import requests
+    from podgen import Podcast
+    # ...
+    changed_podcasts = [
+        # ... multiple Podcast objects here
+    ]
+    Podcast.notify_multiple(requests, changed_podcasts)
+
+Always use the latter form when multiple Podcasts have changed; you'll save
+lots of time since only one request needs to be made per hub.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -57,6 +57,6 @@ User Guide
    user/basic_usage_guide/part_2
    user/basic_usage_guide/part_3
    user/example
-   extending
+   advanced/index
    contributing
    api

--- a/podgen/podcast.py
+++ b/podgen/podcast.py
@@ -23,6 +23,7 @@ import sys
 from podgen.compat import string_types
 import collections
 import inspect
+import warnings
 
 
 _feedgen_version = podgen.version.version_str
@@ -272,14 +273,12 @@ class Podcast(object):
 
         .. note::
 
-           You only need to worry about this attribute if you've `set up
-           PubSubHubbub`_ for your podcast. PodGen does NOT include this
-           functionality for you, and you must notify the hub of new content
-           yourself.
+           You only need to worry about this attribute if you've :doc:`set up
+           PubSubHubbub </advanced/pubsubhubbub>` for your podcast.
 
         .. note::
 
-           In addition to setting this attribute, you should set the
+           In addition to setting this attribute, you must set the
            :attr:`.feed_url` to the canonical URL of this feed. That way, there
            is no confusion about which URL should be given to the PubSubHubbub
            by the podcatcher when subscribing.
@@ -300,9 +299,11 @@ class Podcast(object):
            PubSubHubbub. The `latest version of the standard`_ specifically says
            that publishers MUST use the Link header.
 
+        .. seealso:
+           The :doc:`guide on how to use PubSubHubbub </advanced/pubsubhubbub>`
+              A more detailed walk-through on how to use PubSubHubbub.
+
         .. _PubSubHubbub: https://en.wikipedia.org/wiki/PubSubHubbub
-        .. _set up PubSubHubbub:
-           https://indieweb.org/How_to_publish_and_consume_PubSubHubbub
         .. _Link header: https://tools.ietf.org/html/rfc5988#page-6
         .. _latest version of the standard: http://pubsubhubbub.github.io/PubSubHubbub/pubsubhubbub-core-0.4.html#rfc.section.4
         """
@@ -743,6 +744,119 @@ class Podcast(object):
         :meth:`.Podcast.apply_episode_order` on the other feed, though."""
         for episode in self.episodes:
             episode.position = None
+
+    @classmethod
+    def notify_multiple(cls, requests, feeds, timeout=10.0):
+        """Notify the PubSubHubbub hubs of additions in multiple Podcasts.
+
+        When using PubSubHubbub, you must notify the hub whenever a feed has
+        new entries. Using this method, you can give a list of feeds
+        which all have new content. This saves time compared to
+        :meth:`~.Podcast.notify_hub` since they can be made into one request per
+        hub, instead of having one request per feed per hub.
+
+        The Podcast objects don't need to use the same PubSubHubbub hub.
+
+        :param requests: The requests module, or a Session object.
+        :type requests: requests or requests.Session
+        :param feeds: List of Podcast objects which have new or changed content
+            published.
+        :type feeds: :obj:`list` of :class:`.Podcast`
+        :param timeout: Number of seconds we can wait for the server to respond.
+            Applies to each hub separately. Defaults to ten seconds.
+        :type timeout: float
+        :warnings: UserWarning for each feed that has no value for
+            :attr:`~.Podcast.pubsubhubbub` and :attr:`~.Podcast.feed_url`.
+
+        .. note::
+
+           This method is blocking, and will return when the servers respond.
+
+        .. note::
+
+           For this to work for a given feed, it must have
+           :attr:`~.Podcast.feed_url` and :attr:`~.Podcast.pubsubhubbub` set
+           correctly.
+
+        .. seealso::
+
+           The instance method :meth:`~.Podcast.notify_hub`
+              For notifying a single hub about a single feed
+
+           The :doc:`guide on using PubSubHubbub </advanced/pubsubhubbub>`
+              For a step-for-step guide with examples.
+        """
+        # Which hubs should be notified about what feeds?
+        hubs = dict()
+        for feed in feeds:
+            if feed.pubsubhubbub:
+                hubs.setdefault(feed.pubsubhubbub, []).append(feed)
+            else:
+                warnings.warn("Cannot notify feed %s: pubsubhubbub not set"
+                              % feed)
+
+        # We now have a dictionary which maps a hub to a list of its feeds
+        for hub, hub_feeds in iteritems(hubs):
+            # Create the POST parameters
+            # Tell the PubSubHubbub we are notifying it of updates
+            params = [("hub.mode", "publish")]
+            # Tell the hub which feeds have been updated
+            for feed in hub_feeds:
+                if feed.feed_url:
+                    params.append(("hub.url", feed.feed_url))
+                else:
+                    warnings.warn("Cannot notify feed %s: feed_url not set"
+                                  % feed)
+            # Do the notifying!
+            if len(params) > 1:
+                r = requests.post(hub, data=params, timeout=timeout)
+                r.raise_for_status()
+            else:
+                # No feeds which we can notify this hub of...
+                pass
+
+    def notify_hub(self, requests, timeout=5.0):
+        """Notify this podcast's PubSubHubbub hub about new episode(s).
+
+        When using PubSubHubbub, you must notify it whenever there's a new
+        episode available. Use this method to do
+        so, *after* the new episode is available -- the hub will check the feed
+        to figure out what's new once you do so.
+
+        :param requests: The requests module, or a Session object.
+        :type requests: requests or requests.Session
+        :param timeout: Number of seconds to wait for the hub to respond.
+            Defaults to five seconds.
+        :type timeout: float
+
+        .. note::
+
+           This method is blocking, and will return when the server responds.
+
+        .. note::
+
+           For this to work, this feed must have
+           :attr:`~.Podcast.feed_url` and :attr:`~.Podcast.pubsubhubbub` set
+           correctly.
+
+        .. seealso::
+
+           The class method :meth:`~.Podcast.notify_multiple`
+              For sending notifications about multiple feeds.
+
+           The :doc:`guide on using PubSubHubbub </advanced/pubsubhubbub>`
+              For a step-for-step guide with examples.
+        """
+        if not self.feed_url:
+            raise RuntimeError("Cannot notify hub of this feed, since feed_url "
+                               "is not set.")
+        elif not self.pubsubhubbub:
+            raise RuntimeError("Cannot notify hub of this feed, since "
+                               "pubsubhubbub is not set.")
+        else:
+            self.notify_multiple(requests, [self], timeout=timeout)
+
+
 
     @property
     def last_updated(self):

--- a/podgen/tests/test_podcast.py
+++ b/podgen/tests/test_podcast.py
@@ -538,5 +538,123 @@ class TestPodcast(unittest.TestCase):
         assert xslt_path in generated_feed(minimize=True)
         assert xslt_path in generated_feed(xml_declaration=False)
 
+    # Test for notifying a PubSubHubbub
+    def test_notifyHub(self):
+        url_hub = self.pubsubhubbub
+        url_feed = self.feed_url
+        assertEqual = self.assertEqual
+        wanted_timeout = None
+
+        class MyLittleRequests(object):
+            @staticmethod
+            def post(url, data, timeout, *args, **kwargs):
+                assertEqual(url_hub, url)
+                if wanted_timeout:
+                    # Test that the timeout is equal what we put in
+                    assertEqual(wanted_timeout, timeout)
+                else:
+                    # Test that the default timeout is OK
+                    assert 2.0 < timeout < 10.0, "Too long or short timeout!"
+
+                if isinstance(data, dict):
+                    assert "hub.mode" in data
+                    assertEqual("publish", data['hub.mode'])
+
+                    assert "hub.url" in data
+                    assertEqual(url_feed, data['hub.url'])
+
+                else:
+                    assert ("hub.mode", "publish") in data, \
+                        "Pair (hub.mode, publish) not in %s" % data
+                    assert ("hub.url", url_feed) in data, \
+                        "Pair (hub.url, %s) not in %s" % (url_feed, data)
+
+                class MyLittleResponse(object):
+                    def raise_for_status(self):
+                        pass
+                return MyLittleResponse()
+
+        self.fg.notify_hub(MyLittleRequests)
+        # Test that the timeout parameter is given to requests
+        wanted_timeout = 50.0
+        self.fg.notify_hub(MyLittleRequests, wanted_timeout)
+
+    def test_notifyHubMultiple(self):
+        url_hub = self.pubsubhubbub
+        url_other_hub = "https://pubsubhubbub.example.org"
+        feeds = [Podcast(
+            name="Test1",
+            description="Testing a podcast",
+            website="http://example.com",
+            explicit=False,
+            feed_url="http://example.com/feed1.rss",
+            pubsubhubbub=self.pubsubhubbub),
+                Podcast(
+            name="Test2",
+            description="Testing another podcast",
+            website="http://example.com",
+            explicit=True,
+            feed_url="http://example.com/feed2.rss",
+            pubsubhubbub=self.pubsubhubbub),
+                self.fg
+                ]
+
+        assertEqual = self.assertEqual
+        wanted_timeout = None
+
+        class MyLittleRequests(object):
+            num_feeds = 0
+            num_requests = 0
+
+            @staticmethod
+            def post(url, data, timeout, *args, **kwargs):
+                assert url in (url_hub, url_other_hub)
+
+                if wanted_timeout:
+                    # Test that the timeout is equal what we put in
+                    assertEqual(wanted_timeout, timeout)
+                else:
+                    # Test that the default timeout is OK
+                    assert 5.0 < timeout < 30.0, "Too long or short timeout!"
+
+                assert ("hub.mode", "publish") in data, \
+                    "Pair (hub.mode, publish) not in %s" % data
+                for url_feed in (podcast.feed_url for podcast in feeds
+                                 if podcast.pubsubhubbub == url):
+                    assert ("hub.url", url_feed) in data, \
+                        "Pair (hub.url, %s) not in %s" % (url_feed, data)
+                    MyLittleRequests.num_feeds += 1
+
+                class MyLittleResponse(object):
+                    def raise_for_status(self):
+                        pass
+                MyLittleRequests.num_requests += 1
+                return MyLittleResponse()
+
+        Podcast.notify_multiple(MyLittleRequests, feeds)
+        self.assertEqual(MyLittleRequests.num_feeds, 3)
+        self.assertEqual(MyLittleRequests.num_requests, 1)
+
+        # Test with timeout
+        wanted_timeout = 50.0
+        Podcast.notify_multiple(MyLittleRequests, feeds, timeout=wanted_timeout)
+        self.assertEqual(MyLittleRequests.num_feeds, 6)
+        self.assertEqual(MyLittleRequests.num_requests, 2)
+
+        # Test with one feed with another pubsubhubbub
+        wanted_timeout = None
+        feeds.append(Podcast(
+            name="Test4",
+            description="Testing another pubsubhubbub",
+            website="http://example.com",
+            explicit=True,
+            feed_url="http://example.com/feed4.rss",
+            pubsubhubbub=url_other_hub
+        ))
+        Podcast.notify_multiple(MyLittleRequests, feeds)
+        self.assertEqual(MyLittleRequests.num_feeds, 10)
+        self.assertEqual(MyLittleRequests.num_requests, 4)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Create guide on how to use PubSubHubbub, and reorganize the docs so "Adding new tags" and "Using PubSubHubbub" are placed under "Advanced Topics".