### PR TITLE
Convert ValueError to warning, closes #53

### DIFF
--- a/podgen/episode.py
+++ b/podgen/episode.py
@@ -8,10 +8,14 @@
 
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+import warnings
+
 from lxml import etree
 from datetime import datetime
 import dateutil.parser
 import dateutil.tz
+
+from podgen.not_supported_by_itunes_warning import NotSupportedByItunesWarning
 from podgen.util import formatRFC2822, listToHumanreadableStr
 from podgen.compat import string_types
 from builtins import str
@@ -458,7 +462,8 @@ class Episode(object):
         pixels.
 
         iTunes supports images in JPEG and PNG formats with an RGB color space
-        (CMYK is not supported). The URL must end in ".jpg" or ".png".
+        (CMYK is not supported). The URL must end in ".jpg" or ".png"; a
+        :class:`.NotSupportedByItunesWarning` will be issued if it doesn't.
 
         :type: :obj:`str`
         :RSS: itunes:image
@@ -487,8 +492,8 @@ class Episode(object):
         if image is not None:
             lowercase_image = str(image).lower()
             if not (lowercase_image.endswith(('.jpg', '.jpeg', '.png'))):
-                raise ValueError('Image filename must end with png or jpg, not '
-                                 '.%s' % image.split(".")[-1])
+                warnings.warn('Image filename must end with png or jpg, not '
+                      '%s' % image.split(".")[-1], NotSupportedByItunesWarning)
             self.__image = image
         else:
             self.__image = None

--- a/podgen/podcast.py
+++ b/podgen/podcast.py
@@ -15,6 +15,7 @@ from datetime import datetime
 import dateutil.parser
 import dateutil.tz
 from podgen.episode import Episode
+from podgen.not_supported_by_itunes_warning import NotSupportedByItunesWarning
 from podgen.util import ensure_format, formatRFC2822, listToHumanreadableStr, \
     htmlencode
 from podgen.person import Person
@@ -1050,7 +1051,8 @@ class Podcast(object):
         featured on the iTunes Store.
 
         iTunes supports images in JPEG and PNG formats with an RGB color space
-        (CMYK is not supported). The URL must end in ".jpg" or ".png".
+        (CMYK is not supported). The URL must end in ".jpg" or ".png"; if they
+        don't, a :class:`.NotSupportedByItunesWarning` will be issued.
 
         :type: :obj:`str`
         :RSS: itunes:image
@@ -1070,8 +1072,11 @@ class Podcast(object):
         if image is not None:
             lowercase_itunes_image = image.lower()
             if not (lowercase_itunes_image.endswith(('.jpg', '.jpeg', '.png'))):
-                raise ValueError('Image filename must end with png or jpg, not '
-                                 '.%s' % image.split(".")[-1])
+                warnings.warn\
+                  (
+                    'Image URL must end with png or jpg, not '
+                    '%s' % image.split(".")[-1], NotSupportedByItunesWarning
+                  )
             self.__image = image
         else:
             self.__image = None

--- a/podgen/tests/test_media.py
+++ b/podgen/tests/test_media.py
@@ -22,8 +22,6 @@ import io
 from podgen import Media, NotSupportedByItunesWarning
 import podgen.media
 
-# Because of a bug in the unittest.mock implementation, we must skip some tests
-# in Python 3.4.2
 
 class TestMedia(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
You should be allowed to use whatever you want as
image URL, but not without a warning that it won't work
on iTunes :)