### PR TITLE
Use encoding when writing file, fixes #65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Python 3.3, due to its age and lack of support, and bugs with
   installing `tinytag`.
 
+### Fixed
+
+- `UnicodeEncodeError` when writing a podcast with non-ASCII characters to file
+  in an environment where Python defaults to ASCII encoding.
+- Incompatibility with unicode strings on Python 2.7.
+
 
 ## [1.0.0] - 2017-05-24
 ### Added
 
 - The Podcast and Episode classes for easily generating a podcast out of data,
   and related utilities and classes.
+
+[1.0.0]: https://github.com/tobinus/python-podgen/compare/290045ac...v1.0.0

--- a/podgen/__init__.py
+++ b/podgen/__init__.py
@@ -10,6 +10,10 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
 from .podcast import Podcast
 from .episode import Episode
 from .media import Media

--- a/podgen/__main__.py
+++ b/podgen/__main__.py
@@ -7,6 +7,9 @@
         <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 '''
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
 
 import sys
 import datetime

--- a/podgen/category.py
+++ b/podgen/category.py
@@ -8,6 +8,11 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
+
 class Category(object):
     """Immutable class representing an iTunes category.
 

--- a/podgen/episode.py
+++ b/podgen/episode.py
@@ -8,6 +8,11 @@
 
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+from future.utils import iteritems
+
 import warnings
 
 from lxml import etree
@@ -18,8 +23,6 @@ import dateutil.tz
 from podgen.not_supported_by_itunes_warning import NotSupportedByItunesWarning
 from podgen.util import formatRFC2822, listToHumanreadableStr
 from podgen.compat import string_types
-from builtins import str
-from future.utils import iteritems
 
 
 class Episode(object):
@@ -503,14 +506,14 @@ class Episode(object):
     def explicit(self):
         """Whether this podcast episode contains material which may be
         inappropriate for children.
-        
+
         The value of the podcast's explicit attribute is used by default, if
         this is kept as ``None``.
 
         If you set this to ``True``, an "explicit" parental advisory
-        graphic will appear in the Name column in iTunes. If the value is 
-        ``False``, the parental advisory type is considered Clean, meaning that 
-        no explicit language or adult content is included anywhere in this 
+        graphic will appear in the Name column in iTunes. If the value is
+        ``False``, the parental advisory type is considered Clean, meaning that
+        no explicit language or adult content is included anywhere in this
         episode, and a "clean" graphic will appear.
 
         :type: :obj:`bool`

--- a/podgen/media.py
+++ b/podgen/media.py
@@ -9,11 +9,15 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+from future.moves.urllib.parse import urlparse
+from future.utils import raise_from
+
 import os
 import tempfile
 import warnings
-from future.moves.urllib.parse import urlparse
-from future.utils import raise_from
 import datetime
 
 from tinytag import TinyTag

--- a/podgen/not_supported_by_itunes_warning.py
+++ b/podgen/not_supported_by_itunes_warning.py
@@ -9,5 +9,10 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
+
 class NotSupportedByItunesWarning(UserWarning):
     pass

--- a/podgen/person.py
+++ b/podgen/person.py
@@ -9,6 +9,11 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
+
 class Person(object):
     """Data-oriented class representing a single person or entity.
 

--- a/podgen/podcast.py
+++ b/podgen/podcast.py
@@ -9,7 +9,11 @@
     :license: FreeBSD and LGPL, see license.* for more details.
 
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
 from future.utils import iteritems
+
 from lxml import etree
 from datetime import datetime
 import dateutil.parser

--- a/podgen/podcast.py
+++ b/podgen/podcast.py
@@ -668,7 +668,8 @@ class Podcast(object):
 
            File-like objects given to this method will not be closed.
 
-        :param filename: Name of file to write, or a file-like object, or a URL.
+        :param filename: Name of file to write, or a file-like object (accepting
+            string/unicode, not bytes).
         :type filename: str or fd
         :param minimize: Set to True to disable splitting the feed into multiple
             lines and adding properly indentation, saving bytes at the cost of
@@ -686,7 +687,7 @@ class Podcast(object):
         # Have we got a filename, or a file-like object?
         if isinstance(filename, string_types):
             # It is a string, assume it is filename
-            with open(filename, "w") as fd:
+            with open(filename, "w", encoding=encoding) as fd:
                 fd.write(rss)
         elif hasattr(filename, "write"):
             # It is file-like enough to fool us

--- a/podgen/tests/test_category.py
+++ b/podgen/tests/test_category.py
@@ -8,6 +8,10 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
 import unittest
 
 from podgen import Category

--- a/podgen/tests/test_episode.py
+++ b/podgen/tests/test_episode.py
@@ -8,6 +8,9 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
 
 import unittest
 import warnings
@@ -19,6 +22,7 @@ from podgen import Person, Media, Podcast, htmlencode, Episode, \
 import datetime
 import pytz
 from dateutil.parser import parse as parsedate
+
 
 class TestBaseEpisode(unittest.TestCase):
 

--- a/podgen/tests/test_media.py
+++ b/podgen/tests/test_media.py
@@ -8,11 +8,15 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+from future.utils import iteritems
+
 import os
 import tempfile
 
 import pickle
-from future.utils import iteritems
 import unittest
 import warnings
 from datetime import timedelta

--- a/podgen/tests/test_person.py
+++ b/podgen/tests/test_person.py
@@ -8,6 +8,10 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
 import unittest
 from podgen import Person
 

--- a/podgen/tests/test_podcast.py
+++ b/podgen/tests/test_podcast.py
@@ -11,6 +11,7 @@
 
 import unittest
 import warnings
+import locale
 
 from lxml import etree
 import tempfile
@@ -26,6 +27,8 @@ import dateutil.parser
 class TestPodcast(unittest.TestCase):
 
     def setUp(self):
+        self.existing_locale = locale.setlocale(locale.LC_ALL, None)
+        locale.setlocale(locale.LC_ALL, 'C')
 
         fg = Podcast()
 
@@ -36,7 +39,8 @@ class TestPodcast(unittest.TestCase):
 
         self.name = 'Some Testfeed'
 
-        self.author = Person('John Doe', 'john@example.de')
+        # Use character not in ASCII to catch encoding errors
+        self.author = Person('Jon Døll', 'jon@example.com')
 
         self.website = 'http://example.com'
         self.description = 'This is a cool feed!'
@@ -98,6 +102,9 @@ class TestPodcast(unittest.TestCase):
         def noop(*args, **kwargs):
             pass
         warnings.showwarning = noop
+
+    def tearDown(self):
+        locale.setlocale(locale.LC_ALL, self.existing_locale)
 
     def test_constructor(self):
         # Overwrite fg from setup

--- a/podgen/tests/test_podcast.py
+++ b/podgen/tests/test_podcast.py
@@ -9,6 +9,11 @@
     :license: FreeBSD and LGPL, see license.* for more details.
 """
 
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+from future.utils import raise_from
+
 import unittest
 import warnings
 import locale
@@ -16,7 +21,6 @@ import locale
 from lxml import etree
 import tempfile
 import os
-from future.utils import raise_from
 
 from podgen import NotSupportedByItunesWarning, Person, Category, Podcast
 import podgen.version

--- a/podgen/tests/test_podcast.py
+++ b/podgen/tests/test_podcast.py
@@ -174,6 +174,7 @@ class TestPodcast(unittest.TestCase):
         # Keep track of our temporary file and its filename
         filename = None
         file = None
+        encoding = 'UTF-8'
         try:
             # Get our temporary file name
             file = tempfile.NamedTemporaryFile(delete=False)
@@ -181,9 +182,9 @@ class TestPodcast(unittest.TestCase):
             # Close the file; we will just use its name
             file.close()
             # Write the RSS to the file (overwriting it)
-            fg.rss_file(filename=filename, **kwargs)
+            fg.rss_file(filename=filename, encoding=encoding, **kwargs)
             # Read the resulting RSS
-            with open(filename, "r") as myfile:
+            with open(filename, "r", encoding=encoding) as myfile:
                 rssString = myfile.read()
         finally:
             # We don't need the file any longer, so delete it

--- a/podgen/tests/test_util.py
+++ b/podgen/tests/test_util.py
@@ -8,6 +8,10 @@
     :copyright: 2016, Thorben Dahl <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
 import unittest
 from podgen import util
 

--- a/podgen/util.py
+++ b/podgen/util.py
@@ -9,6 +9,10 @@
         <thorben@sjostrom.no>
     :license: FreeBSD and LGPL, see license.* for more details.
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
+
 import sys, locale
 
 

--- a/podgen/version.py
+++ b/podgen/version.py
@@ -9,6 +9,9 @@
     :license: FreeBSD and LGPL, see license.* for more details.
 
 """
+# Support for Python 2.7
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import *
 
 'Version of python-podgen represented as tuple'
 version = (1, 0, 0)


### PR DESCRIPTION
The user's default encoding was used when writing the file, instead of the specified encoding. On my system (and on Travis CI) UTF-8 is the default, while if you use the C locale, ASCII was used.