### PR TITLE
Fix Travis CI build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   # lxml dropped support for Python 3.4 in version 4.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,4 @@ python:
   - "3.5"
   - "3.6"
 
-before_install: pip install --quiet -r requirements.txt
-
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "3.6"
 
 install:
+  - pip install --upgrade pip
   # lxml dropped support for Python 3.3 in version 4.3.0
   # Must work around bug in tinytag https://github.com/devsnd/tinytag/issues/71
   - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install --no-binary tinytag 'lxml<4.3.0' tinytag; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,11 @@ python:
   - "3.5"
   - "3.6"
 
+install:
+  # lxml dropped support for Python 3.3 in version 4.3.0
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install lxml<4.3.0; fi
+  # lxml dropped support for Python 3.4 in version 4.4.0
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install lxml<4.4.0; fi
+  - pip install -r requirements.txt
+
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ python:
 
 install:
   # lxml dropped support for Python 3.3 in version 4.3.0
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install lxml<4.3.0; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install 'lxml<4.3.0'; fi
   # lxml dropped support for Python 3.4 in version 4.4.0
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install lxml<4.4.0; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install 'lxml<4.4.0'; fi
   - pip install -r requirements.txt
 
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ python:
 
 install:
   # lxml dropped support for Python 3.3 in version 4.3.0
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install 'lxml<4.3.0'; fi
+  # Must work around bug in tinytag https://github.com/devsnd/tinytag/issues/71
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install --no-binary tinytag 'lxml<4.3.0' tinytag; fi
   # lxml dropped support for Python 3.4 in version 4.4.0
   - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install 'lxml<4.4.0'; fi
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,15 @@
 language: python
 
 sudo: required
-dist: trusty
+dist: xenial
 
 python:
-#  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 
 install:
-  - pip install --upgrade pip
-  # lxml dropped support for Python 3.3 in version 4.3.0
-  # Must work around bug in tinytag https://github.com/devsnd/tinytag/issues/71
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then pip install --no-binary tinytag 'lxml<4.3.0' tinytag; fi
   # lxml dropped support for Python 3.4 in version 4.4.0
   - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pip install 'lxml<4.4.0'; fi
   - pip install -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+### Added
+
+- This `CHANGELOG.md` file, for documenting notable changes.
+
+### Removed
+
+- Support for Python 3.3, due to its age and lack of support, and bugs with
+  installing `tinytag`.
+
+
+## [1.0.0] - 2017-05-24
+### Added
+
+- The Podcast and Episode classes for easily generating a podcast out of data,
+  and related utilities and classes.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ head around ambiguous, undocumented APIs. PodGen incorporates the industry's
 best practices and lets you focus on collecting the necessary metadata and
 publishing the podcast.
 
-PodGen is compatible with Python 2.7 and 3.3+.
+PodGen is compatible with Python 2.7 and 3.4+.
 
 
 User Guide

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ PodGen (forked from python-feedgen)
 
 
 This module can be used to generate podcast feeds in RSS format, and is
-compatible with Python 2.7 and 3.3+.
+compatible with Python 2.7 and 3.4+.
 
 It is licensed under the terms of both, the FreeBSD license and the LGPLv3+.
 Choose the one which is more convenient for you. For more details have a look

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         license = 'FreeBSD and LGPLv3+',
         install_requires = ['lxml', 'dateutils', 'future', 'pytz', 'tinytag',
                             'requests'],
+        python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
         classifiers = [
             'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
             'Programming Language :: Python :: 2',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Python version 3.3 gave error with both lxml and tinytag. I was unable to resolve the error of the last one due to Pip not behaving as expected on Travis, and decided that keeping support for 3.3 is not worth the trouble.

Python 3.4 gave an error due to Pip not finding a compatible version of lxml. An additional installation step ensures that a compatible version is installed. 