### PR TITLE
Support for multiple categories/subcategories

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -279,7 +279,7 @@ man_show_urls = True
 
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
-#  dir menu entry, description, category)
+#  dir menu entry, description, categories)
 texinfo_documents = [
     ('index', 'pyPodGen.tex', u'PodGen Documentation',
         u'Lars Kiesow, Thorben Dahl', 'Lernfunk3', 'One line description of project.',

--- a/podgen/__main__.py
+++ b/podgen/__main__.py
@@ -56,7 +56,7 @@ def main():
     p.is_serial = True
     p.language = 'de'
     p.feed_url = 'http://example.com/feeds/myfeed.rss'
-    p.category = Category('Leisure', 'Aviation')
+    p.category = Category([('Leisure', 'Aviation')])
     p.explicit = False
     p.complete = False
     p.new_feed_url = 'http://example.com/new-feed.rss'

--- a/podgen/podcast.py
+++ b/podgen/podcast.py
@@ -225,7 +225,7 @@ class Podcast(object):
         :RSS: itunes:block
         """
 
-        self.__category = None
+        self.__categories = None
 
         self.__image = None
 
@@ -582,12 +582,13 @@ class Podcast(object):
             block = etree.SubElement(channel, '{%s}block' % ITUNES_NS)
             block.text = 'Yes'
 
-        if self.category:
-            category = etree.SubElement(channel, '{%s}category' % ITUNES_NS)
-            category.attrib['text'] = self.category.category
-            if self.category.subcategory:
-                subcategory = etree.SubElement(category, '{%s}category' % ITUNES_NS)
-                subcategory.attrib['text'] = self.category.subcategory
+        if self.categories:
+            for cat in self.categories.categories:
+                category = etree.SubElement(channel, '{%s}category' % ITUNES_NS)
+                category.attrib['text'] = cat[0]
+                if cat[1]:
+                    subcategory = etree.SubElement(category, '{%s}category' % ITUNES_NS)
+                    subcategory.attrib['text'] = cat[1]
 
         if self.image:
             image = etree.SubElement(channel, '{%s}image' % ITUNES_NS)
@@ -1069,27 +1070,26 @@ class Podcast(object):
         self.__web_master = web_master
 
     @property
-    def category(self):
-        """The iTunes category, which appears in the category column
+    def categories(self):
+        """The iTunes categories, which appears in the categories column
         and in iTunes Store listings.
 
         :type: :class:`podgen.Category`
-        :RSS: itunes:category
+        :RSS: itunes:categories
         """
-        return self.__category
+        return self.__categories
 
-    @category.setter
-    def category(self, category):
-        if category is not None:
-            # Check that the category quacks like a duck
-            if hasattr(category, "category") and \
-                    hasattr(category, "subcategory"):
-                self.__category = category
+    @categories.setter
+    def categories(self, categories):
+        if categories is not None:
+            # Check that the categories quacks like a duck
+            if hasattr(categories, "categories"):
+                self.__categories = categories
             else:
                 raise TypeError("A Category(-like) object must be used, got "
-                                "%s" % category)
+                                "%s" % categories)
         else:
-            self.__category = None
+            self.__categories = None
 
     @property
     def image(self):

--- a/podgen/tests/test_category.py
+++ b/podgen/tests/test_category.py
@@ -35,45 +35,45 @@ class TestCategory(unittest.TestCase):
             # Replacement of assertWarns in Python 2.7
             warnings.simplefilter("always", LegacyCategoryWarning)
 
-            c = Category("Arts", "Food")
-            self.assertEqual(c.category, "Arts")
-            self.assertEqual(c.subcategory, "Food")
+            c = Category([("Arts", "Food")])
+            self.assertEqual(c.categories[0][0], "Arts")
+            self.assertEqual(c.categories[0][1], "Food")
 
             # No warning should be given
             # Replacement of assertWarns in Python 2.7
             self.assertEqual(len(w), 0);
 
     def test_constructorWithoutSubcategory(self):
-        c = Category("Arts")
-        self.assertEqual(c.category, "Arts")
-        self.assertTrue(c.subcategory is None)
+        c = Category([("Arts",)])
+        self.assertEqual(c.categories[0][0], "Arts")
+        self.assertTrue(c.categories[0][1] is None)
 
     def test_constructorInvalidCategory(self):
-        self.assertRaises(ValueError, Category, "Farts", "Food")
+        self.assertRaises(ValueError, Category, [("Farts", "Food")])
 
     def test_constructorInvalidSubcategory(self):
-        self.assertRaises(ValueError, Category, "Arts", "Flood")
+        self.assertRaises(ValueError, Category, [("Arts", "Flood")])
 
     def test_constructorSubcategoryWithoutCategory(self):
-        self.assertRaises((ValueError, TypeError), Category, None, "Food")
+        self.assertRaises((ValueError, TypeError, AttributeError), Category, [(None, "Food")])
 
     def test_constructorCaseInsensitive(self):
-        c = Category("arTS", "FOOD")
-        self.assertEqual(c.category, "Arts")
-        self.assertEqual(c.subcategory, "Food")
+        c = Category([("arTS", "FOOD")])
+        self.assertEqual(c.categories[0][0], "Arts")
+        self.assertEqual(c.categories[0][1], "Food")
 
     def test_immutable(self):
-        c = Category("Arts", "Food")
-        self.assertRaises(AttributeError, setattr, c, "category", "Fiction")
-        self.assertEqual(c.category, "Arts")
+        c = Category([("Arts", "Food")])
+        self.assertRaises(AttributeError, setattr, c, "categories", [("Fiction",)])
+        self.assertEqual(c.categories[0][0], "Arts")
 
-        self.assertRaises(AttributeError, setattr, c, "subcategory", "Science Fiction")
-        self.assertEqual(c.subcategory, "Food")
+        self.assertRaises(AttributeError, setattr, c, "categories", [("Fiction", "Science Fiction")])
+        self.assertEqual(c.categories[0][1], "Food")
 
     def test_escapedIsAccepted(self):
-        c = Category("Kids &amp; Family", "Pets &amp; Animals")
-        self.assertEqual(c.category, "Kids & Family")
-        self.assertEqual(c.subcategory, "Pets & Animals")
+        c = Category([("Kids &amp; Family", "Pets &amp; Animals")])
+        self.assertEqual(c.categories[0][0], "Kids & Family")
+        self.assertEqual(c.categories[0][1], "Pets & Animals")
 
     def test_oldCategoryIsAcceptedWithWarning(self):
         # Replacement of assertWarns in Python 2.7
@@ -81,8 +81,8 @@ class TestCategory(unittest.TestCase):
             # Replacement of assertWarns in Python 2.7
             warnings.simplefilter("always", LegacyCategoryWarning)
 
-            c = Category("Government & Organizations")
-            self.assertEqual(c.category, "Government & Organizations")
+            c = Category([("Government & Organizations",)])
+            self.assertEqual(c.categories[0][0], "Government & Organizations")
 
             # Replacement of assertWarns in Python 2.7
             self.assertEqual(len(w), 1)
@@ -94,9 +94,9 @@ class TestCategory(unittest.TestCase):
             # Replacement of assertWarns in Python 2.7
             warnings.simplefilter("always", LegacyCategoryWarning)
 
-            c = Category("Technology", "Podcasting")
-            self.assertEqual(c.category, "Technology")
-            self.assertEqual(c.subcategory, "Podcasting")
+            c = Category([("Technology", "Podcasting")])
+            self.assertEqual(c.categories[0][0], "Technology")
+            self.assertEqual(c.categories[0][1], "Podcasting")
 
             # Replacement of assertWarns in Python 2.7
             self.assertEqual(len(w), 1)
@@ -108,9 +108,9 @@ class TestCategory(unittest.TestCase):
             # Replacement of assertWarns in Python 2.7
             warnings.simplefilter("always", LegacyCategoryWarning)
 
-            c = Category("Science & Medicine", "Medicine")
-            self.assertEqual(c.category, "Science & Medicine")
-            self.assertEqual(c.subcategory, "Medicine")
+            c = Category([("Science & Medicine", "Medicine")])
+            self.assertEqual(c.categories[0][0], "Science & Medicine")
+            self.assertEqual(c.categories[0][1], "Medicine")
 
             # Replacement of assertWarns in Python 2.7
             self.assertEqual(len(w), 1)

--- a/podgen/tests/test_podcast.py
+++ b/podgen/tests/test_podcast.py
@@ -428,7 +428,7 @@ class TestPodcast(unittest.TestCase):
 
     def test_categoryWithoutSubcategory(self):
         c = Category([("Arts",)])
-        self.fg.category = c
+        self.fg.categories = c
         channel = self.fg._create_rss().find("channel")
         itunes_category = channel.find("{%s}category" % self.nsItunes)
         assert itunes_category is not None
@@ -439,7 +439,7 @@ class TestPodcast(unittest.TestCase):
 
     def test_categoryWithSubcategory(self):
         c = Category([("Arts", "Food")])
-        self.fg.category = c
+        self.fg.categories = c
         channel = self.fg._create_rss().find("channel")
         itunes_category = channel.find("{%s}category" % self.nsItunes)
         assert itunes_category is not None

--- a/podgen/tests/test_podcast.py
+++ b/podgen/tests/test_podcast.py
@@ -427,18 +427,18 @@ class TestPodcast(unittest.TestCase):
                          channel.find("webMaster").text)
 
     def test_categoryWithoutSubcategory(self):
-        c = Category("Arts")
+        c = Category([("Arts",)])
         self.fg.category = c
         channel = self.fg._create_rss().find("channel")
         itunes_category = channel.find("{%s}category" % self.nsItunes)
         assert itunes_category is not None
 
-        self.assertEqual(itunes_category.get("text"), c.category)
+        self.assertEqual(itunes_category.get("text"), c.categories[0][0])
 
         assert itunes_category.find("{%s}category" % self.nsItunes) is None
 
     def test_categoryWithSubcategory(self):
-        c = Category("Arts", "Food")
+        c = Category([("Arts", "Food")])
         self.fg.category = c
         channel = self.fg._create_rss().find("channel")
         itunes_category = channel.find("{%s}category" % self.nsItunes)
@@ -446,11 +446,11 @@ class TestPodcast(unittest.TestCase):
         itunes_subcategory = itunes_category\
             .find("{%s}category" % self.nsItunes)
         assert itunes_subcategory is not None
-        self.assertEqual(itunes_subcategory.get("text"), c.subcategory)
+        self.assertEqual(itunes_subcategory.get("text"), c.categories[0][1])
 
     def test_categoryChecks(self):
-        c = ("Arts", "Food")
-        self.assertRaises(TypeError, setattr, self.fg, "category", c)
+        c = ([("Arts", "Food")])
+        self.assertRaises(TypeError, setattr, self.fg, "categories", c)
 
     def test_explicitIsExplicit(self):
         self.fg.explicit = True
@@ -634,6 +634,7 @@ class TestPodcast(unittest.TestCase):
 
         # Test that its contents is correct
         self.assertEqual(podcast_type.text, "serial")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/podgen/warnings.py
+++ b/podgen/warnings.py
@@ -31,7 +31,7 @@ class NotRecommendedWarning(PodgenWarning):
 
 class LegacyCategoryWarning(PodgenWarning):
     """
-    Indicates that the category created is an old category. It will still be
+    Indicates that the categories created is an old categories. It will still be
     accepted by Apple Podcasts, but it would be wise to use the new categories
     since they may have more relevant options for your podcast.
 


### PR DESCRIPTION
This modification adds the ability to set multiple categories, each with an optional subcategory.

`Category` now accepts a single argument: `categories`, which is a list of tuples, each tuple being a category and subcategory couple. Subcategories are optional.
Example:
```pod.categories = Category([("Arts",), ("Business", "Careers"), ("Government",), ("Fiction", "Comedy Fiction")])```
The minimal entry when instantiating a `Category` object is a list of a single tuple with a single entry, eg:
```pod.categories = Category([("Arts",)])```

I've also updated the unit tests in `test_category.py` and `test_podcast.py` to succeed under the new schema.